### PR TITLE
Fixed yValue usage

### DIFF
--- a/src/bar.js
+++ b/src/bar.js
@@ -100,7 +100,7 @@
                     return y(d[yValue]);
                 })
                 .attr("height", function(d) {
-                    return height - y(d.frequency);
+                    return height - y(d[yValue]);
                 }).on('mousedown', function(d) {
                     if (options.onClick)
                         options.onClick(d);


### PR DESCRIPTION
Previously d.frequency was hardcoded in an equation. If you used some other `yValue`, it would return NaN which is not very much drawable.
